### PR TITLE
Fix SSH Node Command for session resumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ To continue a conversation, use the `-r` (resume) flag with the same session ID:
 
 **SSH Node Command (Follow-up):**
 ```bash
-claude -r --session-id {{ $('Code').item.json.sessionId }} -p "Why is one of them down?"
+claude -r {{ $('Code').item.json.sessionId }} -p "Why is one of them down?"
 ```
 
 The `-r` flag resumes the previous session, so Claude remembers the context of your earlier questions.


### PR DESCRIPTION
Updated SSH Node Command syntax for resuming sessions.

In the readme, there is an error when using using the resume flag (-r) and the --session-id in the same command. Claude can only use one or the other. This will error out. 

this is the stderr output
`Error: --session-id cannot be used with --continue or --resume.`